### PR TITLE
#40: Write center coordinates of a building as an object in json

### DIFF
--- a/app/src/main/res/raw/buildings_info.json
+++ b/app/src/main/res/raw/buildings_info.json
@@ -873,10 +873,10 @@
         "Career and Planning Services",
         "Sexual Assault Resource Centre (SARC)"
       ],
-      "centerCoordinates": [
-        -73.5789475,
-        45.4972685
-      ],
+      "centerCoordinates": {
+        "longitude": -73.5789475,
+        "latitude": 45.4972685
+      },
       "height": 68,
       "width": 68,
       "bearing": 34,


### PR DESCRIPTION
bug fix, center coordinates were written in the incorrect form in the previous PR for this task