### PR TITLE
#272: Added a null check to ensure map exists before zooming in

### DIFF
--- a/app/src/main/java/com/example/concordia_campus_guide/Fragments/LocationFragment.java
+++ b/app/src/main/java/com/example/concordia_campus_guide/Fragments/LocationFragment.java
@@ -460,7 +460,9 @@ public class LocationFragment extends Fragment implements OnFloorPickerOnClickLi
 
     private void zoomInLocation(LatLng center) {
         float zoomLevel = 16.5f;
-        mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(center, zoomLevel));
+        if(mMap != null){
+            mMap.moveCamera(CameraUpdateFactory.newLatLngZoom(center, zoomLevel));
+        }
     }
 
     /**


### PR DESCRIPTION
Since the map was not always loaded, the application would crash without the null check