### PR TITLE
#160/Accessibility : Consider accessibility preferences when finding indoor directions

### DIFF
--- a/app/src/main/java/com/example/concordia_campus_guide/ClassConstants.java
+++ b/app/src/main/java/com/example/concordia_campus_guide/ClassConstants.java
@@ -18,8 +18,6 @@ import java.util.List;
 public class  ClassConstants {
     public static final String FINE_LOCATION = Manifest.permission.ACCESS_FINE_LOCATION;
     public static final int LOCATION_PERMISSION_REQUEST_CODE = 1234;
-    public static final String TRUE = "true";
-    public static final String FALSE = "false";
     public static final String DISABILITY_BUTTON = "disability_button";
     public static final String CALENDAR_INTEGRATION_BUTTON = "calendar_integration_button";
     public static final String SHARED_PREFERENCES = "UserPreferences";

--- a/app/src/main/java/com/example/concordia_campus_guide/activities/MainActivity.java
+++ b/app/src/main/java/com/example/concordia_campus_guide/activities/MainActivity.java
@@ -115,8 +115,8 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
 
         SharedPreferences sharedPreferences = getSharedPreferences(ClassConstants.SHARED_PREFERENCES, MODE_PRIVATE);
         for (Map.Entry<CompoundButton, String> entry : toggleButtonAndCorrespondingToggleType.entrySet()) {
-            String value = sharedPreferences.getString(entry.getValue(), ClassConstants.FALSE);
-            entry.getKey().setChecked(value.equals(ClassConstants.TRUE));
+            boolean value = sharedPreferences.getBoolean(entry.getValue(), false);
+            entry.getKey().setChecked(value);
         }
     }
 
@@ -128,9 +128,9 @@ public class MainActivity extends AppCompatActivity implements NavigationView.On
         SharedPreferences.Editor myEdit = sharedPreferences.edit();
 
         for (Map.Entry<CompoundButton, String> entry: toggleButtonAndCorrespondingToggleType.entrySet()) {
-            String value = entry.getKey().isChecked() ? ClassConstants.TRUE : ClassConstants.FALSE;
+            boolean value = entry.getKey().isChecked();
             String toggleType = entry.getValue();
-            myEdit.putString(toggleType, value);
+            myEdit.putBoolean(toggleType, value);
         }
 
         myEdit.commit();

--- a/app/src/main/java/com/example/concordia_campus_guide/activities/RoutesActivity.java
+++ b/app/src/main/java/com/example/concordia_campus_guide/activities/RoutesActivity.java
@@ -67,9 +67,9 @@ public class RoutesActivity extends AppCompatActivity implements DirectionsApiCa
         // Fetching the stored data from the SharedPreference
         SharedPreferences sharedPreferences = getSharedPreferences(ClassConstants.SHARED_PREFERENCES, MODE_PRIVATE);
 
-        String disability = sharedPreferences.getString(ClassConstants.DISABILITY_BUTTON, ClassConstants.FALSE);
+        boolean disability = sharedPreferences.getBoolean(ClassConstants.DISABILITY_BUTTON, false);
 
-        disabilityButton.setSelected(disability.equals(ClassConstants.TRUE));
+        disabilityButton.setSelected(disability);
     }
 
     @Override
@@ -79,8 +79,8 @@ public class RoutesActivity extends AppCompatActivity implements DirectionsApiCa
         // Creating a shared pref object with a file name "UserPreferences" in private mode
         SharedPreferences sharedPreferences = getSharedPreferences(ClassConstants.SHARED_PREFERENCES, MODE_PRIVATE);
         SharedPreferences.Editor myEdit = sharedPreferences.edit();
-        String disabilityBooleanValue = disabilityButton.isSelected() ? ClassConstants.TRUE : ClassConstants.FALSE;
-        myEdit.putString(ClassConstants.DISABILITY_BUTTON, disabilityBooleanValue);
+        boolean disability = disabilityButton.isSelected();
+        myEdit.putBoolean(ClassConstants.DISABILITY_BUTTON, disability);
         myEdit.commit();
     }
 

--- a/app/src/main/java/com/example/concordia_campus_guide/fragments/LocationFragment.java
+++ b/app/src/main/java/com/example/concordia_campus_guide/fragments/LocationFragment.java
@@ -2,6 +2,8 @@ package com.example.concordia_campus_guide.fragments;
 
 import android.Manifest;
 import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
 import android.content.res.Resources;
 import android.location.Location;
@@ -322,7 +324,8 @@ public class LocationFragment extends Fragment implements OnFloorPickerOnClickLi
     }
 
     public void setIndoorPaths(Place from, Place to) {
-        mViewModel.parseWalkingPointList(AppDatabase.getInstance(getContext()), (RoomModel) from, (RoomModel) to);
+        SharedPreferences preferences = getActivity().getSharedPreferences(ClassConstants.SHARED_PREFERENCES, Context.MODE_PRIVATE);
+        mViewModel.parseWalkingPointList(AppDatabase.getInstance(getContext()), preferences, (RoomModel) from, (RoomModel) to);
     }
 
     public void drawOutdoorPaths(final List<DirectionWrapper> outdoorDirections) {

--- a/app/src/main/java/com/example/concordia_campus_guide/helper/IndoorPathHeuristic.java
+++ b/app/src/main/java/com/example/concordia_campus_guide/helper/IndoorPathHeuristic.java
@@ -4,18 +4,24 @@ import com.example.concordia_campus_guide.database.AppDatabase;
 import com.example.concordia_campus_guide.models.PointType;
 import com.example.concordia_campus_guide.models.WalkingPoint;
 
+import java.util.Arrays;
 import java.util.List;
 
 public class IndoorPathHeuristic {
 
     AppDatabase appDatabase;
+    private boolean isStaffAccessibility;
+    private boolean isReducedAccessibility;
 
-    public IndoorPathHeuristic(final AppDatabase appDatabase) {
+    public IndoorPathHeuristic(AppDatabase appDatabase, boolean isStaffAccessiblity, boolean isReducedAccessiblity) {
         this.appDatabase = appDatabase;
+        this.isStaffAccessibility = isStaffAccessiblity;
+        this.isReducedAccessibility = isReducedAccessiblity;
     }
 
     /**
      * The heuristic is based on the distance between the goal and destination coordinates, the further a point from a destination, the bigger the heuristic it will have.
+     *
      * @param currentPoint
      * @param destinationPoint
      * @return
@@ -34,9 +40,24 @@ public class IndoorPathHeuristic {
                             + getEuclideanDistance(accessPoint, destinationPoint);
             }
 
+            // TODO #160: Make sure to change the heuristic to reflect the distance to the nearest accessible point type
             accessPoint = getNearestAccessPointForFloor(currentPoint, PointType.ELEVATOR);
-                return getEuclideanDistance(currentPoint, accessPoint)
-                        + getEuclideanDistance(accessPoint, destinationPoint);
+
+            // If the accessibility is not reduced, return the nearest access point that is accessible by everyone
+            if (!isReducedAccessibility) {
+                WalkingPoint stairAccessPoint = getNearestAccessPointForFloor(currentPoint, PointType.STAIRS);
+                if (stairAccessPoint != null)
+                    accessPoint = getClosestPointToCurrentPointFromList(currentPoint, Arrays.asList(accessPoint, stairAccessPoint));
+            }
+
+            // If staff access points can be considered, return the nearest access point that is accessible by only staff
+            if (isStaffAccessibility) {
+                WalkingPoint staffAccessPoint = getNearestAccessPointForFloor(currentPoint, PointType.STAFF_ELEVATOR);
+                if (staffAccessPoint != null)
+                    accessPoint = getClosestPointToCurrentPointFromList(currentPoint, Arrays.asList(accessPoint, staffAccessPoint));
+            }
+            return getEuclideanDistance(currentPoint, accessPoint)
+                    + getEuclideanDistance(accessPoint, destinationPoint);
         }
 
         return getEuclideanDistance(currentPoint, destinationPoint);
@@ -44,6 +65,7 @@ public class IndoorPathHeuristic {
 
     /**
      * This method returns the nearest access point in a given floor (given the access point type).
+     *
      * @param currentPoint
      * @param accessPointType
      * @return
@@ -56,12 +78,13 @@ public class IndoorPathHeuristic {
 
     /**
      * This method returns the closest access point based on a source location. This is where the logic is.
+     *
      * @param currentPoint
      * @param accessPtList
      * @return
      */
     public WalkingPoint getClosestPointToCurrentPointFromList(final WalkingPoint currentPoint,
-                                                                 final List<WalkingPoint> accessPtList) {
+                                                              final List<WalkingPoint> accessPtList) {
         WalkingPoint closestPoint = null;
         if (!accessPtList.isEmpty()) {
             closestPoint = accessPtList.get(0);
@@ -76,6 +99,7 @@ public class IndoorPathHeuristic {
 
     /**
      * This method returns the euclidean distance between two points based on the pythagorean theorem.
+     *
      * @param firstCoordinate
      * @param secondCoordinate
      * @return

--- a/app/src/main/java/com/example/concordia_campus_guide/helper/PathFinder.java
+++ b/app/src/main/java/com/example/concordia_campus_guide/helper/PathFinder.java
@@ -3,13 +3,13 @@ package com.example.concordia_campus_guide.helper;
 import android.content.SharedPreferences;
 
 import com.example.concordia_campus_guide.ClassConstants;
-import com.example.concordia_campus_guide.Database.AppDatabase;
-import com.example.concordia_campus_guide.Models.Building;
-import com.example.concordia_campus_guide.Models.Floor;
-import com.example.concordia_campus_guide.Models.Place;
-import com.example.concordia_campus_guide.Models.PointType;
-import com.example.concordia_campus_guide.Models.RoomModel;
-import com.example.concordia_campus_guide.Models.WalkingPoint;
+import com.example.concordia_campus_guide.database.AppDatabase;
+import com.example.concordia_campus_guide.models.Building;
+import com.example.concordia_campus_guide.models.Floor;
+import com.example.concordia_campus_guide.models.Place;
+import com.example.concordia_campus_guide.models.PointType;
+import com.example.concordia_campus_guide.models.RoomModel;
+import com.example.concordia_campus_guide.models.WalkingPoint;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/app/src/main/java/com/example/concordia_campus_guide/view_models/LocationFragmentViewModel.java
+++ b/app/src/main/java/com/example/concordia_campus_guide/view_models/LocationFragmentViewModel.java
@@ -1,6 +1,7 @@
 package com.example.concordia_campus_guide.view_models;
 
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Canvas;
@@ -287,8 +288,8 @@ public class LocationFragmentViewModel extends ViewModel {
         return buildings.get(ClassConstants.SGW_CENTER_BUILDING_LABEL).getCenterCoordinatesLatLng();
     }
 
-    public void parseWalkingPointList(AppDatabase appDatabase, RoomModel from, RoomModel to) {
-        PathFinder pf = new PathFinder(appDatabase, from, to);
+    public void parseWalkingPointList(AppDatabase appDatabase, SharedPreferences preferences, RoomModel from, RoomModel to) {
+        PathFinder pf = new PathFinder(appDatabase, preferences, from, to);
         walkingPoints = pf.getPathToDestination();
 
         List<WalkingPoint> floorWalkingPointList;

--- a/app/src/test/java/com/example/concordia_campus_guide/HelpersTest/IndoorPathHeuristicTest.java
+++ b/app/src/test/java/com/example/concordia_campus_guide/HelpersTest/IndoorPathHeuristicTest.java
@@ -56,7 +56,7 @@ public class IndoorPathHeuristicTest {
         when(mockAppDb.walkingPointDao()).thenReturn(mockWalkingPointDao);
         when(mockWalkingPointDao.getAllAccessPointsOnFloor(classRoomInHBuildingWalkingPoint1.getFloorCode(),PointType.ENTRANCE)).thenReturn(Arrays.asList(classRoomInHBuildingWalkingPoint1));
         when(mockWalkingPointDao.getAll()).thenReturn(walkingPointList);
-        indoorPathHeuristic = new IndoorPathHeuristic(mockAppDb);
+        indoorPathHeuristic = new IndoorPathHeuristic(mockAppDb, false, false);
     }
 
     private void settingUpWalkingPoints(){

--- a/app/src/test/java/com/example/concordia_campus_guide/HelpersTest/PathFinderTest.java
+++ b/app/src/test/java/com/example/concordia_campus_guide/HelpersTest/PathFinderTest.java
@@ -2,15 +2,15 @@ package com.example.concordia_campus_guide.HelpersTest;
 
 import android.content.SharedPreferences;
 
-import com.example.concordia_campus_guide.Database.AppDatabase;
-import com.example.concordia_campus_guide.Database.Daos.WalkingPointDao;
-import com.example.concordia_campus_guide.Helper.PathFinder;
-import com.example.concordia_campus_guide.Models.Building;
-import com.example.concordia_campus_guide.Models.Coordinates;
-import com.example.concordia_campus_guide.Models.Floor;
-import com.example.concordia_campus_guide.Models.PointType;
-import com.example.concordia_campus_guide.Models.RoomModel;
-import com.example.concordia_campus_guide.Models.WalkingPoint;
+import com.example.concordia_campus_guide.database.AppDatabase;
+import com.example.concordia_campus_guide.database.daos.WalkingPointDao;
+import com.example.concordia_campus_guide.helper.PathFinder;
+import com.example.concordia_campus_guide.models.Building;
+import com.example.concordia_campus_guide.models.Coordinates;
+import com.example.concordia_campus_guide.models.Floor;
+import com.example.concordia_campus_guide.models.PointType;
+import com.example.concordia_campus_guide.models.RoomModel;
+import com.example.concordia_campus_guide.models.WalkingPoint;
 
 import org.junit.Before;
 import org.junit.Test;

--- a/app/src/test/java/com/example/concordia_campus_guide/HelpersTest/PathFinderTest.java
+++ b/app/src/test/java/com/example/concordia_campus_guide/HelpersTest/PathFinderTest.java
@@ -1,14 +1,16 @@
 package com.example.concordia_campus_guide.HelpersTest;
 
-import com.example.concordia_campus_guide.database.AppDatabase;
-import com.example.concordia_campus_guide.database.daos.WalkingPointDao;
-import com.example.concordia_campus_guide.helper.PathFinder;
-import com.example.concordia_campus_guide.models.Building;
-import com.example.concordia_campus_guide.models.Coordinates;
-import com.example.concordia_campus_guide.models.Floor;
-import com.example.concordia_campus_guide.models.PointType;
-import com.example.concordia_campus_guide.models.RoomModel;
-import com.example.concordia_campus_guide.models.WalkingPoint;
+import android.content.SharedPreferences;
+
+import com.example.concordia_campus_guide.Database.AppDatabase;
+import com.example.concordia_campus_guide.Database.Daos.WalkingPointDao;
+import com.example.concordia_campus_guide.Helper.PathFinder;
+import com.example.concordia_campus_guide.Models.Building;
+import com.example.concordia_campus_guide.Models.Coordinates;
+import com.example.concordia_campus_guide.Models.Floor;
+import com.example.concordia_campus_guide.Models.PointType;
+import com.example.concordia_campus_guide.Models.RoomModel;
+import com.example.concordia_campus_guide.Models.WalkingPoint;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -51,6 +53,9 @@ public class PathFinderTest {
     @Mock
     WalkingPointDao mockWalkingPointDao;
 
+    @Mock
+    SharedPreferences sharedPreferences;
+
     @Before
     public void setUp() {
         MockitoAnnotations.initMocks(this);
@@ -67,7 +72,7 @@ public class PathFinderTest {
         when(mockAppDb.walkingPointDao().getAllWalkingPointsFromPlace(roomStartingPoint.getFloorCode(), roomStartingPoint.getRoomCode())).thenReturn(Arrays.asList(classRoomInHBuildingWalkingPoint1));
         when(mockAppDb.walkingPointDao().getAllWalkingPointsFromPlace(roomDestination.getFloorCode(), roomDestination.getRoomCode())).thenReturn(Arrays.asList(classRoomInHBuildingWalkingPoint2));
 
-        pathFinder = new PathFinder(mockAppDb, roomStartingPoint, roomDestination);
+        pathFinder = new PathFinder(mockAppDb, sharedPreferences, roomStartingPoint, roomDestination);
     }
 
     private void settingUpWalkingPoints(){
@@ -127,7 +132,7 @@ public class PathFinderTest {
         when(mockAppDb.walkingPointDao().getAllWalkingPointsFromPlace(roomInMB.getFloorCode(), roomInMB.getRoomCode())).thenReturn(Arrays.asList(classRoomInMBBuildingWalkingPoint));
         when(mockAppDb.walkingPointDao().getAllAccessPointsOnFloor(classRoomInHBuildingWalkingPoint1.getFloorCode(), PointType.ENTRANCE)).thenReturn(Arrays.asList(entranceHBuildingWalkingPoint));
 
-        PathFinder pathFinderBetweenBuildings = new PathFinder(mockAppDb,roomInH,roomInMB);
+        PathFinder pathFinderBetweenBuildings = new PathFinder(mockAppDb, sharedPreferences, roomInH,roomInMB);
         List<WalkingPoint> walkingPointsToDestination = Arrays.asList(classRoomInHBuildingWalkingPoint1, walkingPoint4, entranceHBuildingWalkingPoint, entranceMBBuildingWalkingPoint, walkingPoint9, classRoomInMBBuildingWalkingPoint);
         assertEquals(walkingPointsToDestination,pathFinderBetweenBuildings.getPathToDestination());
     }


### PR DESCRIPTION
closes #160 
1. Refactor the sharedPreferences to contain boolean values
- Previously, the sharedPreferenced had keys with string values of "true", "false". 
- As it is possible for boolean values to be added to the sharedPreferences, the "true", "false" strings have been replaced by their boolean values
**- Remember to uninstall the application before running this, sinon there will be class conversion errors.**

2. Accessibility pref taken in account for indoor directions
- Shared preferences passed as a parameter to the PathFinder in order to take in account the accessibility pref when coming up with an indoor direction

3. Unit tests refactored to reflect the inclusion of access. pref