### PR TITLE
#285: Added search icon and made search bar rectangular

### DIFF
--- a/app/src/main/res/layout/search_activity.xml
+++ b/app/src/main/res/layout/search_activity.xml
@@ -12,7 +12,7 @@
         android:layout_width="match_parent"
         android:layout_height="55dp"
         android:layout_margin="3dp"
-        android:background="@drawable/rounded_corners_with_border"
+        android:background="@color/whiteBackgroundColor"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
@@ -43,6 +43,17 @@
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintVertical_bias="0.47"
             app:srcCompat="@drawable/ic_arrow_back_24dp" />
+
+        <ImageView
+            android:id="@+id/search_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:paddingEnd="12dp"
+            app:srcCompat="@drawable/search_icon"
+            app:layout_constraintEnd_toEndOf="@id/searchText"
+            app:layout_constraintBottom_toBottomOf="@id/searchText"
+            app:layout_constraintTop_toTopOf="@id/searchText"
+            />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 


### PR DESCRIPTION
fix #285 

Search bar before:
![image](https://user-images.githubusercontent.com/32281531/78965815-258aec80-7acc-11ea-8452-ff9ff90db34e.png)
 
Search bar after:
![image](https://user-images.githubusercontent.com/32281531/78965733-d775e900-7acb-11ea-86d5-56a019343e15.png)

I matched the figma, but the rounded one is nice too. What do you guys think?
