### PR TITLE
#308: arePlacesSeparatedByTunnel reverted to only consider H and MB

### DIFF
--- a/app/src/main/java/com/example/concordia_campus_guide/view_models/PathsViewModel.java
+++ b/app/src/main/java/com/example/concordia_campus_guide/view_models/PathsViewModel.java
@@ -57,11 +57,19 @@ public class PathsViewModel extends ViewModel {
         String entranceFloor = building.getBuildingCode() + "-" + building.getEntranceFloor();
         return appDB.roomDao().getRoomByIdAndFloorCode("entrance", entranceFloor);
     }
-    //TODO: fix this broken function !!IMPORTANT!!
+
     public boolean arePlacesSeparatedByATunnel(Place from, Place to) {
-        return from.getCampus() != null
-                && from.getCampus().equals("SGW")
-                && to.getCampus().equals("SGW");
+        if (from instanceof RoomModel && to instanceof RoomModel) {
+            String floorCode = ((RoomModel) from).getFloorCode();
+            String fromBuilding = floorCode.toUpperCase().substring(0, floorCode.indexOf('-'));
+
+            floorCode = ((RoomModel) to).getFloorCode();
+            String toBuilding = floorCode.toUpperCase().substring(0, floorCode.indexOf('-'));
+
+            return fromBuilding.equalsIgnoreCase("H") && toBuilding.equalsIgnoreCase("MB") ||
+                    fromBuilding.equalsIgnoreCase("MB") && toBuilding.equalsIgnoreCase("H");
+        }
+        return false;
     }
 
     public boolean areInSameBuilding(Place from, Place to) {

--- a/app/src/test/java/com/example/concordia_campus_guide/activities/PathsViewModelTest.java
+++ b/app/src/test/java/com/example/concordia_campus_guide/activities/PathsViewModelTest.java
@@ -61,7 +61,7 @@ public class PathsViewModelTest {
 
     @Test
     public void arePlacesSeparatedByATunnelTest() {
-        assertTrue(pathsViewModel.arePlacesSeparatedByATunnel(fromRoom, toRoom));
+        assertFalse(pathsViewModel.arePlacesSeparatedByATunnel(fromRoom, toRoom));
     }
 
     @Test


### PR DESCRIPTION
- arePlacesSeparatedByTunnel method reverted to how it was before commit #[4dcd4c7f7535ab0dccda2afe15757bbfd0bbb095](https://github.com/Concordia-Campus-Guide/Concordia-Campus-Guide/pull/293/commits/4dcd4c7f7535ab0dccda2afe15757bbfd0bbb095)

close #308 