### PR TITLE
Added missing walking points for rooms 927.02 and 927.03

### DIFF
--- a/app/src/main/res/raw/walking_points.json
+++ b/app/src/main/res/raw/walking_points.json
@@ -4540,7 +4540,6 @@
       "pointType": "STAIRS",
       "connectedPointsId": [
         410,
-        411,
         217
       ],
       "placeCode": "stairs-3"
@@ -4814,8 +4813,7 @@
       "connectedPointsId": [
         69,
         70,
-        412,
-        387
+        412
       ],
       "placeCode": ""
     },

--- a/app/src/main/res/raw/walking_points.json
+++ b/app/src/main/res/raw/walking_points.json
@@ -2925,6 +2925,7 @@
       "floorCode": "H-9",
       "pointType": "NONE",
       "connectedPointsId": [
+        12,
         226,
         227,
         228,

--- a/app/src/main/res/raw/walking_points.json
+++ b/app/src/main/res/raw/walking_points.json
@@ -2795,7 +2795,9 @@
       "floorCode": "H-9",
       "pointType": "CLASSROOM",
       "connectedPointsId": [
-        10
+        10,
+        814,
+        815
       ],
       "placeCode": "927.01"
     },
@@ -5058,7 +5060,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [600,602],
+      "connectedPointsId": [
+        600,
+        602
+      ],
       "placeCode": ""
     },
     {
@@ -5069,7 +5074,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [601,603],
+      "connectedPointsId": [
+        601,
+        603
+      ],
       "placeCode": ""
     },
     {
@@ -5080,7 +5088,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [602,604,611],
+      "connectedPointsId": [
+        602,
+        604,
+        611
+      ],
       "placeCode": ""
     },
     {
@@ -5091,7 +5103,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [603,605,606],
+      "connectedPointsId": [
+        603,
+        605,
+        606
+      ],
       "placeCode": ""
     },
     {
@@ -5116,7 +5132,12 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [604,607,608,609],
+      "connectedPointsId": [
+        604,
+        607,
+        608,
+        609
+      ],
       "placeCode": ""
     },
     {
@@ -5127,7 +5148,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [606],
+      "connectedPointsId": [
+        606
+      ],
       "placeCode": "197.1"
     },
     {
@@ -5138,7 +5161,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [606],
+      "connectedPointsId": [
+        606
+      ],
       "placeCode": "103.1"
     },
     {
@@ -5149,7 +5174,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [606,610],
+      "connectedPointsId": [
+        606,
+        610
+      ],
       "placeCode": ""
     },
     {
@@ -5160,7 +5188,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [609],
+      "connectedPointsId": [
+        609
+      ],
       "placeCode": "140"
     },
     {
@@ -5171,7 +5201,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [603,612],
+      "connectedPointsId": [
+        603,
+        612
+      ],
       "placeCode": ""
     },
     {
@@ -5182,7 +5215,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "LOUNGES",
-      "connectedPointsId": [611,613,689],
+      "connectedPointsId": [
+        611,
+        613,
+        689
+      ],
       "placeCode": "lounge-1"
     },
     {
@@ -5193,7 +5230,13 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [614,612,615,664,689],
+      "connectedPointsId": [
+        614,
+        612,
+        615,
+        664,
+        689
+      ],
       "placeCode": ""
     },
     {
@@ -5204,7 +5247,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [613],
+      "connectedPointsId": [
+        613
+      ],
       "placeCode": "106.1"
     },
     {
@@ -5215,7 +5260,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [613,616,617],
+      "connectedPointsId": [
+        613,
+        616,
+        617
+      ],
       "placeCode": ""
     },
     {
@@ -5226,7 +5275,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [615],
+      "connectedPointsId": [
+        615
+      ],
       "placeCode": "106.2"
     },
     {
@@ -5237,7 +5288,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [618,699],
+      "connectedPointsId": [
+        618,
+        699
+      ],
       "placeCode": ""
     },
     {
@@ -5248,7 +5302,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [617,619,620],
+      "connectedPointsId": [
+        617,
+        619,
+        620
+      ],
       "placeCode": ""
     },
     {
@@ -5259,7 +5317,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "WASHROOM",
-      "connectedPointsId": [618],
+      "connectedPointsId": [
+        618
+      ],
       "placeCode": "womens-2"
     },
     {
@@ -5270,7 +5330,12 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [618,621,650,664],
+      "connectedPointsId": [
+        618,
+        621,
+        650,
+        664
+      ],
       "placeCode": ""
     },
     {
@@ -5298,7 +5363,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "WASHROOM",
-      "connectedPointsId": [621],
+      "connectedPointsId": [
+        621
+      ],
       "placeCode": "mens-1"
     },
     {
@@ -5309,7 +5376,12 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [621,651,624,627],
+      "connectedPointsId": [
+        621,
+        651,
+        624,
+        627
+      ],
       "placeCode": ""
     },
     {
@@ -5320,7 +5392,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [623,626,628],
+      "connectedPointsId": [
+        623,
+        626,
+        628
+      ],
       "placeCode": ""
     },
     {
@@ -5345,7 +5421,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [624],
+      "connectedPointsId": [
+        624
+      ],
       "placeCode": "121.1"
     },
     {
@@ -5356,7 +5434,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [623],
+      "connectedPointsId": [
+        623
+      ],
       "placeCode": "121"
     },
     {
@@ -5367,7 +5447,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [624,629,630],
+      "connectedPointsId": [
+        624,
+        629,
+        630
+      ],
       "placeCode": ""
     },
     {
@@ -5378,7 +5462,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [628],
+      "connectedPointsId": [
+        628
+      ],
       "placeCode": "121.1"
     },
     {
@@ -5389,7 +5475,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [628,633,635],
+      "connectedPointsId": [
+        628,
+        633,
+        635
+      ],
       "placeCode": ""
     },
     {
@@ -5400,7 +5490,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [656],
+      "connectedPointsId": [
+        656
+      ],
       "placeCode": "121.2"
     },
     {
@@ -5411,7 +5503,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [657],
+      "connectedPointsId": [
+        657
+      ],
       "placeCode": "127.2"
     },
     {
@@ -5422,7 +5516,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [630],
+      "connectedPointsId": [
+        630
+      ],
       "placeCode": "127.3"
     },
     {
@@ -5433,7 +5529,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [635],
+      "connectedPointsId": [
+        635
+      ],
       "placeCode": "127.4"
     },
     {
@@ -5444,7 +5542,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [630,634,636],
+      "connectedPointsId": [
+        630,
+        634,
+        636
+      ],
       "placeCode": ""
     },
     {
@@ -5455,7 +5557,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [635,637,638],
+      "connectedPointsId": [
+        635,
+        637,
+        638
+      ],
       "placeCode": ""
     },
     {
@@ -5466,7 +5572,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [636],
+      "connectedPointsId": [
+        636
+      ],
       "placeCode": "127.5"
     },
     {
@@ -5477,7 +5585,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [636,639,640],
+      "connectedPointsId": [
+        636,
+        639,
+        640
+      ],
       "placeCode": ""
     },
     {
@@ -5488,7 +5600,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [638],
+      "connectedPointsId": [
+        638
+      ],
       "placeCode": "130"
     },
     {
@@ -5499,7 +5613,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [638,641],
+      "connectedPointsId": [
+        638,
+        641
+      ],
       "placeCode": ""
     },
     {
@@ -5510,7 +5627,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [640,642],
+      "connectedPointsId": [
+        640,
+        642
+      ],
       "placeCode": ""
     },
     {
@@ -5521,7 +5641,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [641,643],
+      "connectedPointsId": [
+        641,
+        643
+      ],
       "placeCode": ""
     },
     {
@@ -5532,7 +5655,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [642,644,645],
+      "connectedPointsId": [
+        642,
+        644,
+        645
+      ],
       "placeCode": ""
     },
     {
@@ -5543,7 +5670,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [643],
+      "connectedPointsId": [
+        643
+      ],
       "placeCode": ""
     },
     {
@@ -5554,7 +5683,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [643,646,647],
+      "connectedPointsId": [
+        643,
+        646,
+        647
+      ],
       "placeCode": ""
     },
     {
@@ -5565,7 +5698,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [645],
+      "connectedPointsId": [
+        645
+      ],
       "placeCode": "128"
     },
     {
@@ -5576,7 +5711,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [645,648],
+      "connectedPointsId": [
+        645,
+        648
+      ],
       "placeCode": ""
     },
     {
@@ -5587,7 +5725,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [647,649,650],
+      "connectedPointsId": [
+        647,
+        649,
+        650
+      ],
       "placeCode": ""
     },
     {
@@ -5598,7 +5740,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [648],
+      "connectedPointsId": [
+        648
+      ],
       "placeCode": "126"
     },
     {
@@ -5609,7 +5753,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [620,648],
+      "connectedPointsId": [
+        620,
+        648
+      ],
       "placeCode": ""
     },
     {
@@ -5620,7 +5767,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [623,652],
+      "connectedPointsId": [
+        623,
+        652
+      ],
       "placeCode": ""
     },
     {
@@ -5631,7 +5781,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [651,653,654],
+      "connectedPointsId": [
+        651,
+        653,
+        654
+      ],
       "placeCode": ""
     },
     {
@@ -5642,7 +5796,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [652],
+      "connectedPointsId": [
+        652
+      ],
       "placeCode": ""
     },
     {
@@ -5653,7 +5809,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [652,655],
+      "connectedPointsId": [
+        652,
+        655
+      ],
       "placeCode": ""
     },
     {
@@ -5664,7 +5823,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [656,654],
+      "connectedPointsId": [
+        656,
+        654
+      ],
       "placeCode": ""
     },
     {
@@ -5675,7 +5837,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [631,655,657],
+      "connectedPointsId": [
+        631,
+        655,
+        657
+      ],
       "placeCode": ""
     },
     {
@@ -5686,7 +5852,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [632,656,658],
+      "connectedPointsId": [
+        632,
+        656,
+        658
+      ],
       "placeCode": ""
     },
     {
@@ -5697,7 +5867,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [657],
+      "connectedPointsId": [
+        657
+      ],
       "placeCode": ""
     },
     {
@@ -5708,7 +5880,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [600],
+      "connectedPointsId": [
+        600
+      ],
       "placeCode": ""
     },
     {
@@ -5719,7 +5893,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [659,661,662],
+      "connectedPointsId": [
+        659,
+        661,
+        662
+      ],
       "placeCode": ""
     },
     {
@@ -5730,7 +5908,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [660,663],
+      "connectedPointsId": [
+        660,
+        663
+      ],
       "placeCode": ""
     },
     {
@@ -5741,7 +5922,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "WASHROOM",
-      "connectedPointsId": [660],
+      "connectedPointsId": [
+        660
+      ],
       "placeCode": "mens-2"
     },
     {
@@ -5752,7 +5935,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "WASHROOM",
-      "connectedPointsId": [661],
+      "connectedPointsId": [
+        661
+      ],
       "placeCode": "womens-1"
     },
     {
@@ -5763,7 +5948,12 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [665,620,613,689],
+      "connectedPointsId": [
+        665,
+        620,
+        613,
+        689
+      ],
       "placeCode": ""
     },
     {
@@ -5774,7 +5964,12 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [666,664,667,694],
+      "connectedPointsId": [
+        666,
+        664,
+        667,
+        694
+      ],
       "placeCode": ""
     },
     {
@@ -5785,7 +5980,12 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [668,665,669,670],
+      "connectedPointsId": [
+        668,
+        665,
+        669,
+        670
+      ],
       "placeCode": ""
     },
     {
@@ -5796,7 +5996,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [665],
+      "connectedPointsId": [
+        665
+      ],
       "placeCode": "122"
     },
     {
@@ -5807,7 +6009,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [666],
+      "connectedPointsId": [
+        666
+      ],
       "placeCode": "122.1"
     },
     {
@@ -5832,7 +6036,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [666,674,675],
+      "connectedPointsId": [
+        666,
+        674,
+        675
+      ],
       "placeCode": ""
     },
     {
@@ -5843,7 +6051,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [670,672,694],
+      "connectedPointsId": [
+        670,
+        672,
+        694
+      ],
       "placeCode": ""
     },
     {
@@ -5854,7 +6066,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [671,676,673],
+      "connectedPointsId": [
+        671,
+        676,
+        673
+      ],
       "placeCode": ""
     },
     {
@@ -5865,7 +6081,12 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [672,679,678,677],
+      "connectedPointsId": [
+        672,
+        679,
+        678,
+        677
+      ],
       "placeCode": ""
     },
     {
@@ -5876,7 +6097,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "ELEVATOR",
-      "connectedPointsId": [670,710],
+      "connectedPointsId": [
+        670,
+        710
+      ],
       "placeCode": "elevators-1"
     },
     {
@@ -5887,7 +6111,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [670],
+      "connectedPointsId": [
+        670
+      ],
       "placeCode": "194.3"
     },
     {
@@ -5898,7 +6124,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [672,680],
+      "connectedPointsId": [
+        672,
+        680
+      ],
       "placeCode": "102.3"
     },
     {
@@ -5909,7 +6138,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [673],
+      "connectedPointsId": [
+        673
+      ],
       "placeCode": "102.2"
     },
     {
@@ -5920,7 +6151,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [673],
+      "connectedPointsId": [
+        673
+      ],
       "placeCode": "102"
     },
     {
@@ -5931,7 +6164,12 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [673,681,682,683],
+      "connectedPointsId": [
+        673,
+        681,
+        682,
+        683
+      ],
       "placeCode": ""
     },
     {
@@ -5942,7 +6180,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [676],
+      "connectedPointsId": [
+        676
+      ],
       "placeCode": "102.4"
     },
     {
@@ -5953,7 +6193,13 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [679,684,685,686,694],
+      "connectedPointsId": [
+        679,
+        684,
+        685,
+        686,
+        694
+      ],
       "placeCode": ""
     },
     {
@@ -5964,7 +6210,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "STAFF_WASHROOM",
-      "connectedPointsId": [679],
+      "connectedPointsId": [
+        679
+      ],
       "placeCode": "staff washrooms-1"
     },
     {
@@ -5975,7 +6223,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [679],
+      "connectedPointsId": [
+        679
+      ],
       "placeCode": "101.7"
     },
     {
@@ -5986,7 +6236,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [681],
+      "connectedPointsId": [
+        681
+      ],
       "placeCode": "101.6"
     },
     {
@@ -5997,7 +6249,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [681],
+      "connectedPointsId": [
+        681
+      ],
       "placeCode": "101.5"
     },
     {
@@ -6008,7 +6262,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [681,687,688],
+      "connectedPointsId": [
+        681,
+        687,
+        688
+      ],
       "placeCode": ""
     },
     {
@@ -6019,7 +6277,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [686],
+      "connectedPointsId": [
+        686
+      ],
       "placeCode": "101.3"
     },
     {
@@ -6030,7 +6290,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [686],
+      "connectedPointsId": [
+        686
+      ],
       "placeCode": "101.4"
     },
     {
@@ -6041,7 +6303,13 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [612,689,664,613,690],
+      "connectedPointsId": [
+        612,
+        689,
+        664,
+        613,
+        690
+      ],
       "placeCode": ""
     },
     {
@@ -6052,7 +6320,12 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [689,691,694,692],
+      "connectedPointsId": [
+        689,
+        691,
+        694,
+        692
+      ],
       "placeCode": ""
     },
     {
@@ -6063,7 +6336,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [690,695],
+      "connectedPointsId": [
+        690,
+        695
+      ],
       "placeCode": ""
     },
     {
@@ -6074,7 +6350,11 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [690,692,696],
+      "connectedPointsId": [
+        690,
+        692,
+        696
+      ],
       "placeCode": ""
     },
     {
@@ -6085,7 +6365,12 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [692,697,681,694],
+      "connectedPointsId": [
+        692,
+        697,
+        681,
+        694
+      ],
       "placeCode": ""
     },
     {
@@ -6096,7 +6381,13 @@
       },
       "floorCode": "VL-1",
       "pointType": "NONE",
-      "connectedPointsId": [690,665,671,693,681],
+      "connectedPointsId": [
+        690,
+        665,
+        671,
+        693,
+        681
+      ],
       "placeCode": ""
     },
     {
@@ -6107,7 +6398,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [691],
+      "connectedPointsId": [
+        691
+      ],
       "placeCode": "104"
     },
     {
@@ -6118,7 +6411,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [692],
+      "connectedPointsId": [
+        692
+      ],
       "placeCode": "101.1"
     },
     {
@@ -6129,7 +6424,10 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [693,698],
+      "connectedPointsId": [
+        693,
+        698
+      ],
       "placeCode": "101.2"
     },
     {
@@ -6140,7 +6438,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [697],
+      "connectedPointsId": [
+        697
+      ],
       "placeCode": "104.1"
     },
     {
@@ -6151,7 +6451,9 @@
       },
       "floorCode": "VL-1",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [617],
+      "connectedPointsId": [
+        617
+      ],
       "placeCode": "120"
     },
     {
@@ -6162,7 +6464,10 @@
       },
       "floorCode": "VL-2",
       "pointType": "NONE",
-      "connectedPointsId": [701,708],
+      "connectedPointsId": [
+        701,
+        708
+      ],
       "placeCode": ""
     },
     {
@@ -6173,7 +6478,10 @@
       },
       "floorCode": "VL-2",
       "pointType": "NONE",
-      "connectedPointsId": [700,709],
+      "connectedPointsId": [
+        700,
+        709
+      ],
       "placeCode": ""
     },
     {
@@ -6184,7 +6492,14 @@
       },
       "floorCode": "VL-2",
       "pointType": "NONE",
-      "connectedPointsId": [712,703,705,704,710,711],
+      "connectedPointsId": [
+        712,
+        703,
+        705,
+        704,
+        710,
+        711
+      ],
       "placeCode": ""
     },
     {
@@ -6195,7 +6510,12 @@
       },
       "floorCode": "VL-2",
       "pointType": "NONE",
-      "connectedPointsId": [701,702,704,705],
+      "connectedPointsId": [
+        701,
+        702,
+        704,
+        705
+      ],
       "placeCode": ""
     },
     {
@@ -6275,7 +6595,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "STAIRS",
-      "connectedPointsId": [700],
+      "connectedPointsId": [
+        700
+      ],
       "placeCode": "stairs-3"
     },
     {
@@ -6286,7 +6608,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [701],
+      "connectedPointsId": [
+        701
+      ],
       "placeCode": "202.1"
     },
     {
@@ -6297,7 +6621,10 @@
       },
       "floorCode": "VL-2",
       "pointType": "ELEVATOR",
-      "connectedPointsId": [702,674],
+      "connectedPointsId": [
+        702,
+        674
+      ],
       "placeCode": "elevators-1"
     },
     {
@@ -6322,7 +6649,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [702],
+      "connectedPointsId": [
+        702
+      ],
       "placeCode": "202.3"
     },
     {
@@ -6333,7 +6662,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [705],
+      "connectedPointsId": [
+        705
+      ],
       "placeCode": "203.2"
     },
     {
@@ -6344,7 +6675,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [705],
+      "connectedPointsId": [
+        705
+      ],
       "placeCode": "203.1"
     },
     {
@@ -6355,7 +6688,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [705],
+      "connectedPointsId": [
+        705
+      ],
       "placeCode": "201.1"
     },
     {
@@ -6484,7 +6819,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [718],
+      "connectedPointsId": [
+        718
+      ],
       "placeCode": "240"
     },
     {
@@ -6495,7 +6832,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [719],
+      "connectedPointsId": [
+        719
+      ],
       "placeCode": "203.3"
     },
     {
@@ -6506,7 +6845,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [720],
+      "connectedPointsId": [
+        720
+      ],
       "placeCode": "204"
     },
     {
@@ -6517,7 +6858,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [721],
+      "connectedPointsId": [
+        721
+      ],
       "placeCode": "205"
     },
     {
@@ -6528,7 +6871,9 @@
       },
       "floorCode": "VL-2",
       "pointType": "CLASSROOM",
-      "connectedPointsId": [722],
+      "connectedPointsId": [
+        722
+      ],
       "placeCode": "297.1"
     },
     {
@@ -6728,6 +7073,32 @@
         54
       ],
       "placeCode": "lounge-2"
+    },
+    {
+      "id": 814,
+      "coordinate": {
+        "longitude": 45.49707321605269,
+        "latitude": -73.57925456017254
+      },
+      "floorCode": "H-9",
+      "pointType": "CLASSROOM",
+      "connectedPointsId": [
+        220
+      ],
+      "placeCode": "927.02"
+    },
+    {
+      "id": 815,
+      "coordinate": {
+        "longitude": 45.497094366981,
+        "latitude": -73.57928808778524
+      },
+      "floorCode": "H-9",
+      "pointType": "CLASSROOM",
+      "connectedPointsId": [
+        220
+      ],
+      "placeCode": "927.03"
     }
   ]
 }


### PR DESCRIPTION
- App used to crash when we tried getting directions to those classes because a corresponding walking point did not exist

- Changed the connections of pt 220 (for room 927.01)
- Added 2 walking points (814,815) correspondig to rooms (927.02,927.03)
- The rest is just formatting changes [whitespace]

--------------------------
Fixed directions b/w h927-h919
![image](https://user-images.githubusercontent.com/32105523/79273040-56727500-7e70-11ea-9846-e04100405a78.png)
![image](https://user-images.githubusercontent.com/32105523/79273107-773aca80-7e70-11ea-84f0-428a1cf7fb42.png)
--------------------------
Fixed directions from H-827 -> VL1-126 where the directions took the stairs from the 8th to then take the elevators on the 9th.
![image](https://user-images.githubusercontent.com/32105523/79274532-b10cd080-7e72-11ea-9567-8fd5d0cb953d.png)
